### PR TITLE
fix(theme): persist paper color and audio in the browser

### DIFF
--- a/docs/plans/plan-blog-foundation.md
+++ b/docs/plans/plan-blog-foundation.md
@@ -99,6 +99,7 @@ M5 阅读页与全站外壳（可与 M2–M4 并行开工，接入时依赖 M2/M
 - `/blog/` 列表页书架形态；标题锚点与深链。
 - **云字体接入**（见计划原则 6；含 `frontend-design.md` 字体节修订落地）。
 - 全部形态以 [blog-reader-prototype.html](../designs/blog-reader-prototype.html) 为准，硬编码色值映射到 token。
+- 落地后的治理收口（一套主题、一套书册遮罩、一套外壳）见 GitHub #67，不在本模块清单内重开从零落地。
 
 #### M6 划词与注释机制（前端闭环）
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from 'next'
 import { CloudSerifFont } from '@/components/cloud-serif-font'
-import { DEFAULT_THEME, getJourneyStyle, getThemeStyle } from '@/lib/theme'
+import {
+  DEFAULT_THEME,
+  getDocumentThemeCss,
+  getThemeBootScript,
+} from '@/lib/theme'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -15,11 +19,11 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html
-      data-theme={DEFAULT_THEME}
-      lang="zh-CN"
-      style={{ ...getThemeStyle(DEFAULT_THEME), ...getJourneyStyle() }}
-    >
+    <html data-theme={DEFAULT_THEME} lang="zh-CN" suppressHydrationWarning>
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: getDocumentThemeCss() }} />
+        <script dangerouslySetInnerHTML={{ __html: getThemeBootScript() }} />
+      </head>
       <body className="antialiased">
         <CloudSerifFont />
         {children}

--- a/src/features/home-journey/components/home-shell.tsx
+++ b/src/features/home-journey/components/home-shell.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { RopeNavigation } from '@/features/navigation'
 import { useAudioPreference } from '@/lib/audio'
-import { getJourneyStyle, getThemeStyle, useThemePreference } from '@/lib/theme'
+import { useThemePreference } from '@/lib/theme'
 import { HOME_DESTINATIONS, JOURNEY_CONTENT } from '../content'
 
 export type HomeShellProps = {
@@ -79,7 +79,7 @@ export function HomeShell({ mode }: HomeShellProps) {
       className="relative min-h-[100svh] overflow-hidden bg-[var(--journey-bg)] px-4 pb-16 pt-44 text-[var(--journey-paper)] transition-colors duration-[var(--dur-slow)] ease-out md:px-8 md:pt-52"
       data-journey-mode={mode}
       data-testid="home-shell"
-      style={{ ...getThemeStyle(theme), ...getJourneyStyle(), ...backdropStyle }}
+      style={backdropStyle}
     >
       <div
         aria-hidden="true"

--- a/src/features/home-journey/components/mobile-home.tsx
+++ b/src/features/home-journey/components/mobile-home.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { RopeNavigation } from '@/features/navigation'
 import { useAudioPreference } from '@/lib/audio'
-import { getThemeStyle, useThemePreference } from '@/lib/theme'
+import { useThemePreference } from '@/lib/theme'
 import { HOME_DESTINATIONS, JOURNEY_CONTENT } from '../content'
 
 function MobileDestination({
@@ -74,7 +74,6 @@ export function MobileHome() {
       className="relative min-h-[100svh] overflow-hidden bg-[var(--bg)] px-4 pb-10 pt-40 text-[var(--ink)] transition-colors duration-[var(--dur-slow)] ease-out"
       data-journey-mode="mobile"
       data-testid="mobile-home"
-      style={getThemeStyle(theme)}
     >
       <RopeNavigation
         audioEnabled={audioEnabled}

--- a/src/features/navigation/components/settings-panel.tsx
+++ b/src/features/navigation/components/settings-panel.tsx
@@ -74,7 +74,7 @@ export const SettingsPanel = forwardRef<HTMLButtonElement, SettingsPanelProps>(
               小憩设置
             </p>
             <p className="mt-1 text-xs leading-5 text-[var(--ink-muted)]">
-              纸色与音效仅本次访问。本地作者模式会写入本机。
+              纸色与音效会记在这台浏览器里。本地作者模式同样写入本机。
             </p>
           </div>
           <button

--- a/src/lib/audio/audio-preference.ts
+++ b/src/lib/audio/audio-preference.ts
@@ -2,10 +2,44 @@
 
 import { useCallback, useSyncExternalStore } from 'react'
 
+export const AUDIO_STORAGE_KEY = 'blog-yusheng:audio-enabled:v1'
+
 type PreferenceListener = () => void
 
 let audioEnabled = false
+let didHydrate = false
 const listeners = new Set<PreferenceListener>()
+
+function readStoredAudio(): boolean {
+  try {
+    return window.localStorage.getItem(AUDIO_STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function persistAudio(enabled: boolean): void {
+  try {
+    if (enabled) {
+      window.localStorage.setItem(AUDIO_STORAGE_KEY, '1')
+    } else {
+      window.localStorage.removeItem(AUDIO_STORAGE_KEY)
+    }
+  } catch {
+    // Private mode / quota must not break the audio toggle.
+  }
+}
+
+function emit(): void {
+  listeners.forEach((listener) => listener())
+}
+
+function hydrateAudio(): boolean {
+  if (didHydrate) return audioEnabled
+  didHydrate = true
+  audioEnabled = readStoredAudio()
+  return audioEnabled
+}
 
 function subscribe(listener: PreferenceListener): () => void {
   listeners.add(listener)
@@ -13,18 +47,31 @@ function subscribe(listener: PreferenceListener): () => void {
 }
 
 function getSnapshot(): boolean {
-  return audioEnabled
+  return hydrateAudio()
 }
 
 function getServerSnapshot(): boolean {
   return false
 }
 
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event) => {
+    if (event.key !== AUDIO_STORAGE_KEY) return
+    const next = event.newValue === '1'
+    if (next === audioEnabled) return
+    audioEnabled = next
+    didHydrate = true
+    emit()
+  })
+}
+
 export function setAudioEnabled(enabled: boolean): void {
-  if (audioEnabled === enabled) return
+  if (didHydrate && audioEnabled === enabled) return
 
   audioEnabled = enabled
-  listeners.forEach((listener) => listener())
+  didHydrate = true
+  persistAudio(enabled)
+  emit()
 }
 
 export type AudioPreferenceController = {

--- a/src/lib/audio/index.ts
+++ b/src/lib/audio/index.ts
@@ -1,4 +1,5 @@
 export {
+  AUDIO_STORAGE_KEY,
   setAudioEnabled,
   useAudioPreference,
   type AudioPreferenceController,

--- a/src/lib/theme/index.ts
+++ b/src/lib/theme/index.ts
@@ -1,9 +1,13 @@
 export {
   DEFAULT_THEME,
+  getDocumentThemeCss,
   getJourneyStyle,
+  getThemeBootScript,
   getThemeLabel,
   getThemeStyle,
+  isThemeName,
   JOURNEY_VARIABLES,
+  THEME_STORAGE_KEY,
   THEMES,
   type CssVariableStyle,
   type ThemeName,

--- a/src/lib/theme/tokens.ts
+++ b/src/lib/theme/tokens.ts
@@ -144,6 +144,31 @@ export const JOURNEY_VARIABLES = {
 
 export type CssVariableStyle = CSSProperties & Record<`--${string}`, string>
 
+export const THEME_STORAGE_KEY = 'blog-yusheng:theme:v1'
+
+export function isThemeName(value: string): value is ThemeName {
+  return THEMES.some((item) => item.id === value)
+}
+
+function cssDeclarations(vars: Record<string, string>): string {
+  return Object.entries(vars)
+    .map(([name, value]) => `${name}:${value}`)
+    .join(';')
+}
+
+export function getDocumentThemeCss(): string {
+  const root = cssDeclarations({ ...SHARED_VARIABLES, ...JOURNEY_VARIABLES })
+  const themes = THEMES.map(({ id }) => {
+    return `html[data-theme="${id}"]{${cssDeclarations(THEME_COLORS[id])}}`
+  }).join('')
+  return `:root{${root}}${themes}`
+}
+
+export function getThemeBootScript(): string {
+  const ids = THEMES.map((item) => item.id)
+  return `(function(){try{var t=localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});if(${JSON.stringify(ids)}.indexOf(t)<0)return;document.documentElement.setAttribute("data-theme",t);}catch(e){}})();`
+}
+
 export function getThemeStyle(theme: ThemeName): CssVariableStyle {
   return { ...SHARED_VARIABLES, ...THEME_COLORS[theme] }
 }

--- a/src/lib/theme/use-theme-preference.ts
+++ b/src/lib/theme/use-theme-preference.ts
@@ -1,20 +1,95 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 import {
   DEFAULT_THEME,
-  getThemeStyle,
+  THEME_STORAGE_KEY,
   THEMES,
+  isThemeName,
   type ThemeName,
 } from './tokens'
 
-function applyThemeToDocument(theme: ThemeName): void {
-  const root = document.documentElement
+type PreferenceListener = () => void
 
-  root.dataset.theme = theme
-  for (const [name, value] of Object.entries(getThemeStyle(theme))) {
-    root.style.setProperty(name, value)
+let currentTheme: ThemeName = DEFAULT_THEME
+let didHydrate = false
+const listeners = new Set<PreferenceListener>()
+
+function readStoredTheme(): ThemeName {
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+    if (stored && isThemeName(stored)) return stored
+  } catch {
+    // Private mode / quota must not break theming.
   }
+  return DEFAULT_THEME
+}
+
+function persistTheme(theme: ThemeName): void {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+  } catch {
+    // Private mode / quota must not break theming.
+  }
+}
+
+function applyThemeName(theme: ThemeName): void {
+  document.documentElement.dataset.theme = theme
+}
+
+function emit(): void {
+  listeners.forEach((listener) => listener())
+}
+
+function hydrateTheme(): ThemeName {
+  if (didHydrate) return currentTheme
+  didHydrate = true
+  const fromDom = document.documentElement.dataset.theme
+  if (fromDom && isThemeName(fromDom)) {
+    currentTheme = fromDom
+    return currentTheme
+  }
+  currentTheme = readStoredTheme()
+  applyThemeName(currentTheme)
+  return currentTheme
+}
+
+export function setTheme(theme: ThemeName): void {
+  currentTheme = theme
+  didHydrate = true
+  applyThemeName(theme)
+  persistTheme(theme)
+  emit()
+}
+
+function subscribe(listener: PreferenceListener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event) => {
+    if (event.key !== THEME_STORAGE_KEY) return
+    const next =
+      event.newValue && isThemeName(event.newValue)
+        ? event.newValue
+        : DEFAULT_THEME
+    if (next === currentTheme) return
+    currentTheme = next
+    didHydrate = true
+    applyThemeName(next)
+    emit()
+  })
+}
+
+function getSnapshot(): ThemeName {
+  return hydrateTheme()
+}
+
+function getServerSnapshot(): ThemeName {
+  return DEFAULT_THEME
 }
 
 export type ThemePreferenceController = {
@@ -23,21 +98,12 @@ export type ThemePreferenceController = {
   cycleTheme: () => void
 }
 
-export function useThemePreference(
-  initialTheme: ThemeName = DEFAULT_THEME,
-): ThemePreferenceController {
-  const [theme, setTheme] = useState<ThemeName>(initialTheme)
-
-  useEffect(() => {
-    applyThemeToDocument(theme)
-  }, [theme])
-
+export function useThemePreference(): ThemePreferenceController {
+  const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
   const cycleTheme = useCallback(() => {
-    setTheme((currentTheme) => {
-      const currentIndex = THEMES.findIndex((item) => item.id === currentTheme)
-      return THEMES[(currentIndex + 1) % THEMES.length].id
-    })
-  }, [])
+    const currentIndex = THEMES.findIndex((item) => item.id === theme)
+    setTheme(THEMES[(currentIndex + 1) % THEMES.length].id)
+  }, [theme])
 
   return { theme, setTheme, cycleTheme }
 }

--- a/tests/browser/theme-preference.spec.ts
+++ b/tests/browser/theme-preference.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test'
+
+const articlePath = '/blog/p0-kitchen-sink/'
+const mistAccent = '#2f7d95'
+
+async function waitForReader(page: import('@playwright/test').Page) {
+  await page.goto(articlePath)
+  await expect(page.locator('[data-reader-boot-veil]')).toHaveCount(0, {
+    timeout: 3_000,
+  })
+}
+
+test('所选纸色与音效刷新、换路由后仍保持', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('blog-yusheng:theme:v1', 'mist')
+    window.localStorage.setItem('blog-yusheng:audio-enabled:v1', '1')
+  })
+
+  await page.goto(articlePath, { waitUntil: 'domcontentloaded' })
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'mist')
+  expect(
+    await page.locator('html').evaluate((element) => {
+      return getComputedStyle(element).getPropertyValue('--accent').trim()
+    }),
+  ).toBe(mistAccent)
+
+  await expect(page.locator('[data-reader-boot-veil]')).toHaveCount(0, {
+    timeout: 3_000,
+  })
+
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'mist')
+  expect(
+    await page.locator('html').evaluate((element) => {
+      return getComputedStyle(element).getPropertyValue('--accent').trim()
+    }),
+  ).toBe(mistAccent)
+
+  await page.goto('/blog/')
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'mist')
+
+  await page.goto('/')
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'mist')
+  const skip = page.getByRole('button', { name: /跳过/ })
+  if (await skip.isVisible()) await skip.click()
+
+  await waitForReader(page)
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'mist')
+  const center = page.locator('[data-reader-center]')
+  const box = await center.boundingBox()
+  expect(box).not.toBeNull()
+  await page.mouse.move(box!.x + box!.width / 2, 24)
+  await expect(
+    page.getByRole('button', { name: '开启音效偏好' }),
+  ).toHaveCount(0)
+  await expect(
+    page.getByRole('button', { name: '关闭音效偏好' }),
+  ).toHaveAttribute('aria-pressed', 'true')
+})

--- a/tests/unit/theme-tokens.test.ts
+++ b/tests/unit/theme-tokens.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { getThemeStyle } from '../../src/lib/theme/tokens'
+import {
+  getDocumentThemeCss,
+  getThemeBootScript,
+  getThemeStyle,
+  THEME_STORAGE_KEY,
+} from '../../src/lib/theme/tokens'
 
 describe('reader prototype theme tokens', () => {
   it.each([
@@ -20,5 +25,22 @@ describe('reader prototype theme tokens', () => {
     expect(style['--font-mono']).toBe(
       '"JetBrains Mono", ui-monospace, SFMono-Regular, Consolas, monospace',
     )
+  })
+
+  it('emits html[data-theme] color tables from the same token source', () => {
+    const css = getDocumentThemeCss()
+    expect(css).toContain('html[data-theme="paper"]{')
+    expect(css).toContain('html[data-theme="mist"]{')
+    expect(css).toContain('--bg:#e6edf1')
+    expect(css).toContain('--accent:#2f7d95')
+    expect(css).toContain('--journey-void:#050813')
+    expect(css).toContain('--ease-damp:cubic-bezier(.22,.82,.28,1)')
+  })
+
+  it('boots only by writing a stored data-theme onto html', () => {
+    const script = getThemeBootScript()
+    expect(script).toContain(THEME_STORAGE_KEY)
+    expect(script).toContain('setAttribute("data-theme",t)')
+    expect(script).not.toContain('setProperty')
   })
 })


### PR DESCRIPTION
## Summary

- 选过的纸色和音效会记在这台浏览器里，刷新和换路由不再打回宣纸黄 / 音效关。
- html 上的 `data-theme` 成为常规 UI 的唯一主题权威；进页书册跟着同一份 `--accent`。

## Scope

- In scope:
  - 主题与音效持久化、跨页同一份 store、首屏阻塞脚本、设置文案、回归测试
- Out of scope:
  - 灰圈 loading / 书册唯一化（#69）
  - 404/error 灰页（#70）
  - 绳挂两棵树合并（#71）

## Key Changes

- `src/lib/theme/`：token 表生成 `html[data-theme]` CSS；模块 store 读写 localStorage
- `src/app/layout.tsx`：首屏脚本只写 `data-theme`，避免静态页先闪宣纸黄
- `src/lib/audio/`：与主题同一套本机生命周期，默认仍为关
- 首页 / 移动首页不再在 section 上覆盖一份主题 style
- Playwright：选择 mist 后刷新、进 `/blog/` `/` 仍保持；音效 `aria-pressed` 仍为开

## Validation

- `pnpm lint`: pass
- `pnpm tsc --noEmit`: pass
- `pnpm test -- tests/unit/theme-tokens.test.ts`: pass（6）
- `pnpm test:browser -- tests/browser/theme-preference.spec.ts`: pass
- `pnpm test:browser -- tests/browser/reader-chrome.spec.ts`: pass（5）
- `pnpm build`: pass

## Risks and Rollback

- 主要风险：静态导出下 React hydrate 与阻塞脚本的 `data-theme` 竞争。html 已 `suppressHydrationWarning`，颜色走 CSS 选择器而不是 React inline style。
- 监控点：换主题后硬刷新、从首页进博客时书册强调色。
- 回滚思路：还原本 PR。

## Related Issues

- Related to #67

Closes #68
