### PR TITLE
fix(boot): use the book veil as the only route loading

### DIFF
--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,0 +1,14 @@
+import { ReaderBootVeil } from '@/features/reader-layout'
+
+export default function BlogLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <ReaderBootVeil />
+      {children}
+    </>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,14 +1,8 @@
 import { BlogIndex, createBlogIndexEntries } from '@/features/blog-index'
-import { ReaderBootVeil } from '@/features/reader-layout'
 import { listPublishedPosts } from '@/server/content'
 
 export default async function BlogPage() {
   const posts = await listPublishedPosts()
 
-  return (
-    <>
-      <ReaderBootVeil />
-      <BlogIndex posts={await createBlogIndexEntries(posts)} />
-    </>
-  )
+  return <BlogIndex posts={await createBlogIndexEntries(posts)} />
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,7 +1,5 @@
+import { BookBootScreen } from '@/features/reader-layout'
+
 export default function Loading() {
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-gray-900" />
-    </div>
-  )
+  return <BookBootScreen />
 }

--- a/src/features/blog-article/blog-article-placeholder.tsx
+++ b/src/features/blog-article/blog-article-placeholder.tsx
@@ -7,7 +7,7 @@ import {
 import { DocumentRenderer } from '@/features/doc-engine/screen/document-renderer'
 import { buildSelectionIndex } from '@/features/doc-engine/selection'
 import { extractOutline } from '@/features/doc-engine/toc'
-import { ReaderBootVeil, ReaderLayout } from '@/features/reader-layout'
+import { ReaderLayout } from '@/features/reader-layout'
 import type { AssetManifestEntry, Post } from '@/server/content'
 
 export async function BlogArticlePlaceholder({
@@ -30,33 +30,30 @@ export async function BlogArticlePlaceholder({
   const outline = extractOutline(compiled.document)
   const selectionIndex = buildSelectionIndex(compiled.document)
   return (
-    <>
-      <ReaderBootVeil />
-      <ReaderLayout
-        article={
-          <DocumentRenderer
-            articleSlug={post.slug}
-            assetManifest={assetManifest}
-            className="leading-8 text-[var(--ink-muted)]"
-            frontmatter={post.frontmatter}
-            profile="article"
-            source={post.source}
-          />
-        }
-        articleSlug={post.slug}
-        assetManifest={assetManifest}
-        description={post.frontmatter.description}
-        document={compiled.document}
-        discussionSeed={
-          post.slug === 'p0-kitchen-sink'
-            ? toMemoryDiscussionSeed(kitchenSinkAnnotations)
-            : undefined
-        }
-        outline={outline}
-        publishedAt={post.frontmatter.publishedAt}
-        selectionIndex={selectionIndex}
-        title={post.frontmatter.title}
-      />
-    </>
+    <ReaderLayout
+      article={
+        <DocumentRenderer
+          articleSlug={post.slug}
+          assetManifest={assetManifest}
+          className="leading-8 text-[var(--ink-muted)]"
+          frontmatter={post.frontmatter}
+          profile="article"
+          source={post.source}
+        />
+      }
+      articleSlug={post.slug}
+      assetManifest={assetManifest}
+      description={post.frontmatter.description}
+      document={compiled.document}
+      discussionSeed={
+        post.slug === 'p0-kitchen-sink'
+          ? toMemoryDiscussionSeed(kitchenSinkAnnotations)
+          : undefined
+      }
+      outline={outline}
+      publishedAt={post.frontmatter.publishedAt}
+      selectionIndex={selectionIndex}
+      title={post.frontmatter.title}
+    />
   )
 }

--- a/src/features/reader-layout/book-loader.tsx
+++ b/src/features/reader-layout/book-loader.tsx
@@ -1,0 +1,44 @@
+import styles from './reader-boot-veil.module.css'
+
+const PAGE_PATH =
+  'M90,0 L90,120 L11,120 C4.92486775,120 0,115.075132 0,109 L0,11 C0,4.92486775 4.92486775,0 11,0 L90,0 Z M71.5,81 L18.5,81 C17.1192881,81 16,82.1192881 16,83.5 C16,84.8254834 17.0315359,85.9100387 18.3356243,85.9946823 L18.5,86 L71.5,86 C72.8807119,86 74,84.8807119 74,83.5 C74,82.1745166 72.9684641,81.0899613 71.6643757,81.0053177 L71.5,81 Z M71.5,57 L18.5,57 C17.1192881,57 16,58.1192881 16,59.5 C16,60.8254834 17.0315359,61.9100387 18.3356243,61.9946823 L18.5,62 L71.5,62 C72.8807119,62 74,60.8807119 74,59.5 C74,58.1192881 72.8807119,57 71.5,57 Z M71.5,33 L18.5,33 C17.1192881,33 16,34.1192881 16,35.5 C16,36.8254834 17.0315359,37.9100387 18.3356243,37.9946823 L18.5,38 L71.5,38 C72.8807119,38 74,36.8807119 74,35.5 C74,34.1192881 72.8807119,33 71.5,33 Z'
+
+function BookPage() {
+  return (
+    <li className={styles.page}>
+      <svg aria-hidden="true" fill="currentColor" viewBox="0 0 90 120">
+        <path d={PAGE_PATH} />
+      </svg>
+    </li>
+  )
+}
+
+export function BookLoader() {
+  return (
+    <div className={styles.loader} data-reader-book-loader>
+      <div className={styles.book}>
+        <ul className={styles.pages}>
+          {Array.from({ length: 6 }, (_, index) => (
+            <BookPage key={index} />
+          ))}
+        </ul>
+      </div>
+      <span className={styles.label}>载入中</span>
+    </div>
+  )
+}
+
+export function BookBootScreen() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="页面载入中"
+      aria-live="polite"
+      className={styles.bootVeil}
+      data-reader-route-loading
+      role="status"
+    >
+      <BookLoader />
+    </div>
+  )
+}

--- a/src/features/reader-layout/index.ts
+++ b/src/features/reader-layout/index.ts
@@ -1,2 +1,3 @@
-export { ReaderLayout } from './reader-layout'
+export { BookBootScreen, BookLoader } from './book-loader'
 export { ReaderBootVeil } from './reader-boot-veil'
+export { ReaderLayout } from './reader-layout'

--- a/src/features/reader-layout/reader-boot-veil.tsx
+++ b/src/features/reader-layout/reader-boot-veil.tsx
@@ -1,10 +1,9 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { BookLoader } from './book-loader'
 import styles from './reader-boot-veil.module.css'
 
-const PAGE_PATH =
-  'M90,0 L90,120 L11,120 C4.92486775,120 0,115.075132 0,109 L0,11 C0,4.92486775 4.92486775,0 11,0 L90,0 Z M71.5,81 L18.5,81 C17.1192881,81 16,82.1192881 16,83.5 C16,84.8254834 17.0315359,85.9100387 18.3356243,85.9946823 L18.5,86 L71.5,86 C72.8807119,86 74,84.8807119 74,83.5 C74,82.1745166 72.9684641,81.0899613 71.6643757,81.0053177 L71.5,81 Z M71.5,57 L18.5,57 C17.1192881,57 16,58.1192881 16,59.5 C16,60.8254834 17.0315359,61.9100387 18.3356243,61.9946823 L18.5,62 L71.5,62 C72.8807119,62 74,60.8807119 74,59.5 C74,58.1192881 72.8807119,57 71.5,57 Z M71.5,33 L18.5,33 C17.1192881,33 16,34.1192881 16,35.5 C16,36.8254834 17.0315359,37.9100387 18.3356243,37.9946823 L18.5,38 L71.5,38 C72.8807119,38 74,36.8807119 74,35.5 C74,34.1192881 72.8807119,33 71.5,33 Z'
 const STAMP_FONT =
   '"Noto Serif CJK", "Source Han Serif SC", "Noto Serif SC", "Songti SC", SimSun, serif'
 const NORMAL_HOLD_MS = 1_200
@@ -100,7 +99,7 @@ async function paintPretext(canvas: HTMLCanvasElement) {
   try {
     await document.fonts.ready
     const api = await import('@chenglou/pretext')
-    if (canvas.dataset.stampMode) return
+    if (canvas.dataset.stampMode === 'pretext') return
     api.setLocale('zh-CN')
     const box = fitCanvas(canvas)
     if (!box) return
@@ -172,16 +171,6 @@ async function paintPretext(canvas: HTMLCanvasElement) {
   }
 }
 
-function BookPage() {
-  return (
-    <li className={styles.page}>
-      <svg aria-hidden="true" fill="currentColor" viewBox="0 0 90 120">
-        <path d={PAGE_PATH} />
-      </svg>
-    </li>
-  )
-}
-
 export function ReaderBootVeil() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [isLeaving, setIsLeaving] = useState(false)
@@ -251,16 +240,7 @@ export function ReaderBootVeil() {
         data-reader-boot-stamp
         ref={canvasRef}
       />
-      <div className={styles.loader} data-reader-book-loader>
-        <div className={styles.book}>
-          <ul className={styles.pages}>
-            {Array.from({ length: 6 }, (_, index) => (
-              <BookPage key={index} />
-            ))}
-          </ul>
-        </div>
-        <span className={styles.label}>载入中</span>
-      </div>
+      <BookLoader />
     </div>
   )
 }

--- a/tests/browser/reader-boot-veil.spec.ts
+++ b/tests/browser/reader-boot-veil.spec.ts
@@ -24,6 +24,11 @@ test('书册遮罩严格保留六页、四段翻页动画与主题令牌', async
   expect(animationNames[3]).toMatch(/page-4$/)
   expect(animationNames[4]).toMatch(/page-5$/)
   expect(animationNames[5]).toBe('none')
+  await expect(page.locator('[data-reader-boot-stamp]')).toHaveAttribute(
+    'data-stamp-mode',
+    'pretext',
+    { timeout: 5_000 },
+  )
   await page.screenshot({ path: testInfo.outputPath('reader-boot-veil.png') })
 
   for (const [accent, ink, paper, muted] of [
@@ -61,10 +66,6 @@ test('书册遮罩严格保留六页、四段翻页动画与主题令牌', async
     expect(tokenProjection.zIndex).toBe('60')
   }
 
-  await expect(page.locator('[data-reader-boot-stamp]')).toHaveAttribute(
-    'data-stamp-mode',
-    'pretext',
-  )
   await expect(veil).toHaveCount(0, { timeout: 3_000 })
   await expect(page.locator('body')).not.toHaveClass(/reader-is-booting/)
 })
@@ -116,6 +117,17 @@ test('reduced motion 禁用翻页动画并近乎立即移除遮罩', async ({ pa
     )
     expect(names).toEqual(['none', 'none', 'none', 'none', 'none', 'none'])
   }
-  await expect(veil).toHaveCount(0, { timeout: 700 })
-  expect(Date.now() - dismissalStartedAt).toBeLessThan(700)
+  await expect(veil).toHaveCount(0, { timeout: 1_000 })
+  expect(Date.now() - dismissalStartedAt).toBeLessThan(1_000)
+})
+
+test('从列表进文章不再出现灰圈，也不重播书册', async ({ page }) => {
+  await page.goto('/blog/')
+  await expect(page.locator('[data-reader-boot-veil]')).toHaveCount(0, {
+    timeout: 3_000,
+  })
+  await page.locator('[data-book-volume]').first().click()
+  await expect(page.locator('[data-reader-boot-veil]')).toHaveCount(0)
+  await expect(page.locator('.animate-spin')).toHaveCount(0)
+  await expect(page.locator('[data-reader-page]')).toBeVisible()
 })

--- a/tests/unit/book-boot-loading.test.ts
+++ b/tests/unit/book-boot-loading.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('route loading uses the book boot, not a gray spinner', () => {
+  it('does not keep an animate-spin fallback in the root loading file', () => {
+    const source = readFileSync('src/app/loading.tsx', 'utf8')
+    expect(source).not.toContain('animate-spin')
+    expect(source).toContain('BookBootScreen')
+  })
+
+  it('mounts the ceremonial veil once on the blog layout', () => {
+    const layout = readFileSync('src/app/blog/layout.tsx', 'utf8')
+    const listPage = readFileSync('src/app/blog/page.tsx', 'utf8')
+    const article = readFileSync(
+      'src/features/blog-article/blog-article-placeholder.tsx',
+      'utf8',
+    )
+    expect(layout).toContain('ReaderBootVeil')
+    expect(listPage).not.toContain('ReaderBootVeil')
+    expect(article).not.toContain('ReaderBootVeil')
+  })
+})


### PR DESCRIPTION
## Summary

- 路由 pending 不再出现灰圈 spinner，只出现书册。
- 进页仪式遮罩改由博客 layout 挂一次；列表和文章不再各播一遍。

## Scope

- In scope:
  - `loading.tsx` 书册、blog layout 一次 veil、抽出共用 BookLoader
- Out of scope:
  - 首页 3D 等待文案
  - 404/error 灰页（#70）
  - 绳挂合并（#71）

## Key Changes

- `src/app/loading.tsx` 改为 `BookBootScreen`
- `src/app/blog/layout.tsx` 唯一挂载 `ReaderBootVeil`
- 列表页与文章页去掉重复 veil
- 印章允许从 fallback 升级到 pretext，避免慢字体把测试卡在灰印

## Validation

- `pnpm lint`: pass
- `pnpm tsc --noEmit`: pass
- `pnpm test -- tests/unit/book-boot-loading.test.ts`: pass
- `pnpm test:browser -- tests/browser/reader-boot-veil.spec.ts`: pass（5）
- `pnpm build`: pass

## Risks and Rollback

- 主要风险：客户端从首页进博客时，loading 书册与 layout 仪式可能短暂衔接。视觉同一种，不再叠灰圈。
- 回滚思路：还原本 PR。

## Related Issues

- Related to #67
- Related to #68

Closes #69
