### PR TITLE
fix(ui): restyle 404 and error pages with paper tokens

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+const actionClassName =
+  'mt-6 inline-flex min-h-11 items-center justify-center rounded-sm border border-[var(--line)] bg-[var(--accent)] px-4 text-sm font-semibold tracking-[0.12em] text-[var(--bg-elevated)] transition-colors duration-[var(--dur-fast)] ease-out hover:border-[var(--ink)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]'
+
 export default function Error({
   error,
   reset,
@@ -8,15 +11,21 @@ export default function Error({
   reset: () => void
 }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-8">
-      <h2 className="text-2xl font-bold">出错了</h2>
-      <p className="mt-2 text-gray-600">{error.message}</p>
-      <button
-        onClick={reset}
-        className="mt-4 rounded bg-gray-900 px-4 py-2 text-white hover:bg-gray-800"
-      >
-        重试
-      </button>
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[var(--bg)] px-6 py-16 text-[var(--ink)]">
+      <section className="w-full max-w-md border border-[var(--line)] bg-[var(--bg-elevated)] p-8 shadow-[0_24px_60px_var(--shadow-color)]">
+        <p className="text-xs font-semibold tracking-[0.28em] text-[var(--accent)]">
+          羽升书房
+        </p>
+        <h2 className="mt-4 [font-family:var(--font-serif)] text-3xl font-semibold tracking-[0.12em]">
+          出错了
+        </h2>
+        <p className="mt-3 text-sm leading-7 text-[var(--ink-muted)]">
+          {error.message}
+        </p>
+        <button className={actionClassName} onClick={reset} type="button">
+          重试
+        </button>
+      </section>
     </div>
   )
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,5 +1,11 @@
 'use client'
 
+import { DEFAULT_THEME, getJourneyStyle, getThemeStyle } from '@/lib/theme'
+import './globals.css'
+
+const actionClassName =
+  'mt-6 inline-flex min-h-11 items-center justify-center rounded-sm border border-[var(--line)] bg-[var(--accent)] px-4 text-sm font-semibold tracking-[0.12em] text-[var(--bg-elevated)] transition-colors duration-[var(--dur-fast)] ease-out hover:border-[var(--ink)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]'
+
 export default function GlobalError({
   error,
   reset,
@@ -8,17 +14,27 @@ export default function GlobalError({
   reset: () => void
 }) {
   return (
-    <html lang="zh-CN">
-      <body>
-        <div className="flex min-h-screen flex-col items-center justify-center p-8">
-          <h2 className="text-2xl font-bold">系统错误</h2>
-          <p className="mt-2 text-gray-600">{error.message}</p>
-          <button
-            onClick={reset}
-            className="mt-4 rounded bg-gray-900 px-4 py-2 text-white hover:bg-gray-800"
-          >
-            重试
-          </button>
+    <html
+      data-theme={DEFAULT_THEME}
+      lang="zh-CN"
+      style={{ ...getThemeStyle(DEFAULT_THEME), ...getJourneyStyle() }}
+    >
+      <body className="antialiased">
+        <div className="flex min-h-screen flex-col items-center justify-center bg-[var(--bg)] px-6 py-16 text-[var(--ink)]">
+          <section className="w-full max-w-md border border-[var(--line)] bg-[var(--bg-elevated)] p-8 shadow-[0_24px_60px_var(--shadow-color)]">
+            <p className="text-xs font-semibold tracking-[0.28em] text-[var(--accent)]">
+              羽升书房
+            </p>
+            <h2 className="mt-4 [font-family:var(--font-serif)] text-3xl font-semibold tracking-[0.12em]">
+              系统错误
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-[var(--ink-muted)]">
+              {error.message}
+            </p>
+            <button className={actionClassName} onClick={reset} type="button">
+              重试
+            </button>
+          </section>
         </div>
       </body>
     </html>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,16 +1,25 @@
 import Link from 'next/link'
 
+const actionClassName =
+  'mt-6 inline-flex min-h-11 items-center justify-center rounded-sm border border-[var(--line)] bg-[var(--accent)] px-4 text-sm font-semibold tracking-[0.12em] text-[var(--bg-elevated)] transition-colors duration-[var(--dur-fast)] ease-out hover:border-[var(--ink)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]'
+
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-8">
-      <h1 className="mb-4 text-4xl font-bold">404</h1>
-      <p className="mb-4 text-gray-600">页面不存在</p>
-      <Link
-        href="/"
-        className="rounded bg-gray-900 px-4 py-2 text-white hover:bg-gray-800"
-      >
-        返回首页
-      </Link>
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[var(--bg)] px-6 py-16 text-[var(--ink)]">
+      <section className="w-full max-w-md border border-[var(--line)] bg-[var(--bg-elevated)] p-8 shadow-[0_24px_60px_var(--shadow-color)]">
+        <p className="text-xs font-semibold tracking-[0.28em] text-[var(--accent)]">
+          羽升书房
+        </p>
+        <h1 className="mt-4 [font-family:var(--font-serif)] text-4xl font-semibold tracking-[0.18em]">
+          404
+        </h1>
+        <p className="mt-3 text-sm leading-7 text-[var(--ink-muted)]">
+          页面不存在。也许写错了路径，也许这页还没装订。
+        </p>
+        <Link className={actionClassName} href="/" prefetch={false}>
+          返回首页
+        </Link>
+      </section>
     </div>
   )
 }

--- a/tests/browser/not-found.spec.ts
+++ b/tests/browser/not-found.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test'
+
+test('404 走书卷 token，不是脚手架灰页', async ({ page }) => {
+  const response = await page.goto('/this-page-does-not-exist/')
+  expect(response?.status()).toBe(404)
+  await expect(page.getByRole('heading', { name: '404' })).toBeVisible()
+  await expect(page.getByText('页面不存在')).toBeVisible()
+  await expect(page.locator('.bg-gray-900, .text-gray-600, .bg-gray-800')).toHaveCount(
+    0,
+  )
+  expect(
+    await page.locator('html').evaluate((element) => {
+      return getComputedStyle(element).getPropertyValue('--bg').trim()
+    }),
+  ).not.toBe('')
+  await expect(page.getByRole('link', { name: '返回首页' })).toBeVisible()
+})

--- a/tests/unit/error-pages.test.ts
+++ b/tests/unit/error-pages.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const grayScaffold = /gray-(600|800|900)/
+
+describe('fault pages use paper tokens instead of gray scaffold', () => {
+  it.each([
+    'src/app/not-found.tsx',
+    'src/app/error.tsx',
+    'src/app/global-error.tsx',
+  ])('%s has no gray-600/800/900 classes', (path) => {
+    const source = readFileSync(path, 'utf8')
+    expect(source).not.toMatch(grayScaffold)
+    expect(source).toContain('var(--bg)')
+    expect(source).toContain('var(--accent)')
+  })
+})


### PR DESCRIPTION
## Summary

- 404 / error / global-error 不再使用脚手架灰字灰按钮。
- 三页走 `--bg` `--ink` `--accent` 等语义 token，看起来像本站书卷页。

## Scope

- In scope:
  - 三张故障页的配色与纸面卡片
- Out of scope:
  - 错误页上完整绳挂导航（#71）
  - 404 再播进页翻书

## Key Changes

- `src/app/not-found.tsx`、`error.tsx`、`global-error.tsx` 改用主题 token
- `global-error` 自带 html 时写入默认主题变量，避免脱离根 layout 后掉色

## Validation

- `pnpm lint`: pass
- `pnpm tsc --noEmit`: pass
- `pnpm test -- tests/unit/error-pages.test.ts`: pass
- `pnpm test:browser -- tests/browser/not-found.spec.ts`: pass
- `pnpm build`: pass

## Risks and Rollback

- 主要风险：`global-error` 替换整棵 html，不经过根 layout。已在该页内联默认主题。
- 回滚思路：还原本 PR。

## Related Issues

- Related to #67
- Related to #68

Closes #70
