### PR TITLE
feat(blog-index): 目录树与书签旁展示文章标签

### DIFF
--- a/src/features/blog-index/blog-index.module.css
+++ b/src/features/blog-index/blog-index.module.css
@@ -604,6 +604,33 @@
   transform-origin: 50% 100%;
 }
 
+/* 文章标签贴在竖签右侧，不参与命中，避免挡住小书脊点击 */
+.bookmarkTipTags {
+  position: absolute;
+  left: calc(100% + 0.45rem);
+  bottom: 0;
+  display: flex;
+  margin: 0;
+  padding: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.28rem;
+  list-style: none;
+}
+
+.bookmarkTipTag {
+  padding: 0.12rem 0.4rem;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
+  color: var(--ink-muted);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  white-space: nowrap;
+  writing-mode: horizontal-tb;
+}
+
 /* 签条纸：双层细框（线装书题签式样），随主题 token 变色 */
 .bookmarkTipBody {
   padding: 3px;
@@ -824,6 +851,12 @@
   font-weight: 650;
   letter-spacing: 0.05em;
   line-height: 1.45;
+}
+
+.chapterTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .chapterDescription {

--- a/src/features/blog-index/catalog-helpers.ts
+++ b/src/features/blog-index/catalog-helpers.ts
@@ -18,6 +18,39 @@ export function formatChapterDate(iso: string): string {
   return CHAPTER_DATE_FORMATTER.format(new Date(iso))
 }
 
+/** First-seen unique tags; empty input yields an empty list. */
+export function uniqueTags(
+  tags: readonly string[] | undefined,
+): readonly string[] {
+  if (!tags || tags.length === 0) {
+    return []
+  }
+
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const tag of tags) {
+    if (seen.has(tag)) continue
+    seen.add(tag)
+    result.push(tag)
+  }
+  return result
+}
+
+export const BOOKMARK_TAG_LIMIT = 4
+
+export function bookmarkTagOverflow(
+  tags: readonly string[] | undefined,
+): { readonly visible: readonly string[]; readonly extra: number } {
+  const unique = uniqueTags(tags)
+  if (unique.length <= BOOKMARK_TAG_LIMIT) {
+    return { visible: unique, extra: 0 }
+  }
+  return {
+    visible: unique.slice(0, BOOKMARK_TAG_LIMIT),
+    extra: unique.length - BOOKMARK_TAG_LIMIT,
+  }
+}
+
 export function readCatalogHash(): string {
   return decodeURIComponent(window.location.hash.replace(/^#/, ''))
 }

--- a/src/features/blog-index/shelf-stack.tsx
+++ b/src/features/blog-index/shelf-stack.tsx
@@ -4,9 +4,11 @@ import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import styles from './blog-index.module.css'
 import {
+  bookmarkTagOverflow,
   formatChapterDate,
   hashString,
   readCatalogHash,
+  uniqueTags,
 } from './catalog-helpers'
 import type { ShelfBook } from './create-shelf-books'
 
@@ -35,6 +37,38 @@ type BookmarkTip = {
   readonly top: number
   readonly title: string
   readonly index: number
+  readonly tags: readonly string[]
+}
+
+function BookmarkTipView({ tip }: { readonly tip: BookmarkTip }) {
+  const { extra, visible } = bookmarkTagOverflow(tip.tags)
+
+  return (
+    <div
+      className={styles.bookmarkTip}
+      role="tooltip"
+      style={{ left: `${tip.left}px`, top: `${tip.top}px` }}
+    >
+      <div className={styles.bookmarkTipBody}>
+        <div className={styles.bookmarkTipFrame}>
+          <span className={styles.bookmarkTipTitle}>{tip.title}</span>
+          <span className={styles.bookmarkTipSeal}>{tip.index + 1}</span>
+        </div>
+      </div>
+      {visible.length > 0 ? (
+        <ul className={styles.bookmarkTipTags} data-bookmark-tags>
+          {visible.map((tag) => (
+            <li className={styles.bookmarkTipTag} key={tag}>
+              {tag}
+            </li>
+          ))}
+          {extra > 0 ? (
+            <li className={styles.bookmarkTipTag}>+{extra}</li>
+          ) : null}
+        </ul>
+      ) : null}
+    </div>
+  )
 }
 
 /** 单本「方向书」：左窄书脊 + 右侧书页，点击后书页绕左书脊平转 174°，露出文章书脊架 */
@@ -101,6 +135,9 @@ function Tome({ book, open, onToggle }: TomeProps) {
   const dateLabel = latest
     ? formatChapterDate(latest.frontmatter.publishedAt)
     : null
+  const coverTags = uniqueTags(
+    book.chapters.flatMap((entry) => entry.frontmatter.tags ?? []),
+  ).slice(0, 3)
 
   // 悬浮书脊 → 竖式题签从书顶滑出，展示章节完整标题（渲染在 tome 层，逃逸滚动容器的 overflow 裁剪）
   const showTip = useCallback(
@@ -119,6 +156,7 @@ function Tome({ book, open, onToggle }: TomeProps) {
         top: rect.top - rootRect.top,
         title: chapter.frontmatter.title,
         index: chapterIndex,
+        tags: uniqueTags(chapter.frontmatter.tags),
       })
     },
     [book.chapters],
@@ -166,21 +204,15 @@ function Tome({ book, open, onToggle }: TomeProps) {
                   <h2 className={styles.titleBig}>{book.title}</h2>
                   {book.summary && <p className={styles.desc}>{book.summary}</p>}
                 </div>
-                <div className={styles.tags}>
-                  {Array.from(
-                    new Set(
-                      book.chapters.flatMap(
-                        (entry) => entry.frontmatter.tags ?? [],
-                      ),
-                    ),
-                  )
-                    .slice(0, 3)
-                    .map((tag) => (
+                {coverTags.length > 0 ? (
+                  <div className={styles.tags}>
+                    {coverTags.map((tag) => (
                       <span className={styles.tag} key={tag}>
                         {tag}
                       </span>
                     ))}
-                </div>
+                  </div>
+                ) : null}
               </div>
               <div className={styles.arrow}>↗</div>
             </div>
@@ -249,18 +281,7 @@ function Tome({ book, open, onToggle }: TomeProps) {
 
       {/* 悬浮题签：竖式签条从书顶滑出，展示章节完整标题（pointer-events 关闭，不影响点击） */}
       {open && tip && (
-        <div
-          className={styles.bookmarkTip}
-          role="tooltip"
-          style={{ left: `${tip.left}px`, top: `${tip.top}px` }}
-        >
-          <div className={styles.bookmarkTipBody}>
-            <div className={styles.bookmarkTipFrame}>
-              <span className={styles.bookmarkTipTitle}>{tip.title}</span>
-              <span className={styles.bookmarkTipSeal}>{tip.index + 1}</span>
-            </div>
-          </div>
-        </div>
+        <BookmarkTipView tip={tip} />
       )}
     </div>
   )

--- a/src/features/blog-index/tree-index.tsx
+++ b/src/features/blog-index/tree-index.tsx
@@ -6,6 +6,7 @@ import styles from './blog-index.module.css'
 import {
   formatChapterDate,
   readCatalogHash,
+  uniqueTags,
   writeCatalogHash,
 } from './catalog-helpers'
 import type { ShelfBook } from './create-shelf-books'
@@ -69,32 +70,44 @@ function TreeGroup({ book }: { readonly book: ShelfBook }) {
       <div className={styles.treeGroupBody} data-open={open} ref={bodyRef}>
         <div className={styles.treeGroupInner}>
           <ol className={styles.chapters}>
-            {book.chapters.map((entry, index) => (
-              <li key={entry.slug}>
-                <Link
-                  className={styles.chapter}
-                  href={`/blog/${entry.slug}/`}
-                  prefetch={false}
-                  tabIndex={open ? undefined : -1}
-                >
-                  <span className={styles.chapterIndex}>第{index + 1}章</span>
-                  <span className={styles.chapterBody}>
-                    <span className={styles.chapterTitle}>
-                      {entry.frontmatter.title}
+            {book.chapters.map((entry, index) => {
+              const tags = uniqueTags(entry.frontmatter.tags)
+              return (
+                <li key={entry.slug}>
+                  <Link
+                    className={styles.chapter}
+                    href={`/blog/${entry.slug}/`}
+                    prefetch={false}
+                    tabIndex={open ? undefined : -1}
+                  >
+                    <span className={styles.chapterIndex}>第{index + 1}章</span>
+                    <span className={styles.chapterBody}>
+                      <span className={styles.chapterTitle}>
+                        {entry.frontmatter.title}
+                      </span>
+                      {tags.length > 0 ? (
+                        <span className={styles.chapterTags} data-chapter-tags>
+                          {tags.map((tag) => (
+                            <span className={styles.tag} key={tag}>
+                              {tag}
+                            </span>
+                          ))}
+                        </span>
+                      ) : null}
+                      <span className={styles.chapterDescription}>
+                        {entry.frontmatter.description}
+                      </span>
                     </span>
-                    <span className={styles.chapterDescription}>
-                      {entry.frontmatter.description}
+                    <span className={styles.chapterMeta}>
+                      <time dateTime={entry.frontmatter.publishedAt}>
+                        {formatChapterDate(entry.frontmatter.publishedAt)}
+                      </time>
+                      <span>约 {entry.readingMinutes} 分钟</span>
                     </span>
-                  </span>
-                  <span className={styles.chapterMeta}>
-                    <time dateTime={entry.frontmatter.publishedAt}>
-                      {formatChapterDate(entry.frontmatter.publishedAt)}
-                    </time>
-                    <span>约 {entry.readingMinutes} 分钟</span>
-                  </span>
-                </Link>
-              </li>
-            ))}
+                  </Link>
+                </li>
+              )
+            })}
           </ol>
         </div>
       </div>

--- a/tests/browser/content-routes.spec.ts
+++ b/tests/browser/content-routes.spec.ts
@@ -29,6 +29,13 @@ async function openKitchenSinkFromCatalog(page: Page) {
     'true',
   )
   await expect(articleLink).toBeVisible()
+  await expect(articleLink.locator('[data-chapter-tags]')).toContainText('P0')
+  await expect(articleLink.locator('[data-chapter-tags]')).toContainText(
+    '内容引擎',
+  )
+  await expect(articleLink.locator('[data-chapter-tags]')).toContainText(
+    '中文验收',
+  )
   return articleLink
 }
 
@@ -97,4 +104,34 @@ test('博客书架在窄屏走目录树且不横向溢出', async ({ page }) => 
     viewportWidth: window.innerWidth,
   }))
   expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth)
+
+  const looseGroup = page.locator('#uncategorized')
+  await looseGroup.getByRole('button').click()
+  await expect(looseGroup.locator('[data-chapter-tags]')).toContainText('P0')
+})
+
+test('书库悬停小书脊时书签旁显示标签', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await page.goto('/blog/')
+  await waitForCatalog(page)
+
+  const shelf = page.locator('[data-catalog-shelf]')
+  if (!(await shelf.isVisible())) {
+    test.skip(true, '当前视口走目录树，不渲染书库')
+  }
+
+  const tome = page.locator('[data-book-slug="uncategorized"]')
+  await tome.click()
+  const spine = tome.locator(`a[href="${KITCHEN_SINK_HREF}"]`)
+  await expect(spine).toBeVisible()
+  await spine.dispatchEvent('mouseover')
+  const tooltip = page.getByRole('tooltip')
+  await expect(tooltip).toBeVisible()
+  await expect(tooltip.locator('[data-bookmark-tags]')).toContainText('P0')
+  await expect(tooltip.locator('[data-bookmark-tags]')).toContainText('内容引擎')
+
+  await spine.evaluate((element) => {
+    if (element instanceof HTMLAnchorElement) element.click()
+  })
+  await expect(page).toHaveURL(/\/blog\/p0-kitchen-sink\/$/)
 })

--- a/tests/unit/catalog-tags.test.ts
+++ b/tests/unit/catalog-tags.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BOOKMARK_TAG_LIMIT,
+  bookmarkTagOverflow,
+  uniqueTags,
+} from '../../src/features/blog-index/catalog-helpers'
+
+describe('uniqueTags', () => {
+  it('returns an empty list when tags are missing or empty', () => {
+    expect(uniqueTags(undefined)).toEqual([])
+    expect(uniqueTags([])).toEqual([])
+  })
+
+  it('keeps first-seen order and drops duplicates', () => {
+    expect(uniqueTags(['UI', 'Prompt', 'UI', 'Agent'])).toEqual([
+      'UI',
+      'Prompt',
+      'Agent',
+    ])
+  })
+})
+
+describe('bookmarkTagOverflow', () => {
+  it('shows every tag when the list fits the bookmark', () => {
+    expect(bookmarkTagOverflow(['UI', 'UX'])).toEqual({
+      extra: 0,
+      visible: ['UI', 'UX'],
+    })
+  })
+
+  it(`keeps ${BOOKMARK_TAG_LIMIT} chips and counts the rest`, () => {
+    expect(
+      bookmarkTagOverflow(['日常', '生活', '医学', 'AI', '社团', '家庭']),
+    ).toEqual({
+      extra: 2,
+      visible: ['日常', '生活', '医学', 'AI'],
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- 每篇小博客的 `tags` 出现在目录树章行，以及书库悬停小书脊后的竖式书签旁边。
- 无标签不占位；书签旁最多显示 4 个并标 `+N`。不改 3D 抽出与点击进文。

## Scope

- In scope:
  - 目录树章行标签
  - 书库悬浮书签旁标签
  - 封面整册聚合仍最多 3 个，无标签时不画空条
- Out of scope:
  - 标签筛选 / 标签页 / 按标签路由
  - 把 `docs/ops/post-tags.md` 接进构建校验

## Key Changes

- `tree-index.tsx`：标题与摘要之间渲染该篇 tags
- `shelf-stack.tsx`：题签状态带 tags；右侧小签 `pointer-events` 仍由题签容器关闭
- `catalog-helpers.ts`：`uniqueTags` / `bookmarkTagOverflow`
- `tests/browser/content-routes.spec.ts`：目录树、窄屏、书签旁与小书脊 `HTMLAnchorElement.click()` 进文

## Validation

- `pnpm lint`: pass
- `pnpm tsc --noEmit`: pass
- `pnpm test`: pass（含 `catalog-tags`）
- `pnpm build`: pass
- `pnpm exec playwright test tests/browser/content-routes.spec.ts`: 3 passed（含书签旁标签 + 点击进 `/blog/p0-kitchen-sink/`）

## Risks and Rollback

- 主要风险：3D 命中区回归（悬停抽出、点击关书）。本 PR 未改 `.tomeOpen .bookshelf` 的 pointer-events，也未改 `closest('a')` 早退。
- 监控点：`/blog/` 书库悬停小书脊应抽出，点击应进文章。
- 回滚思路：revert 本 squash。

## Related Issues

- Parent: #96
- Depends on #97

Closes #98
